### PR TITLE
Fix vcad_build.sh script error when not using proxy

### DIFF
--- a/VCAC-A/Intel_Media_Analytics_Node/scripts/vcad_build.sh
+++ b/VCAC-A/Intel_Media_Analytics_Node/scripts/vcad_build.sh
@@ -661,14 +661,15 @@ install_vcad() {
 		fi
 	fi
          #set git proxy
-        if [ ! $HTTP_PROXY ] ; then
+        if [ -z "${HTTP_PROXY-}" ] ; then
            git_proxy_flag=0
           
         else
            git_proxy_flag=1
-           git_http_proxy=$HTTP_PROXY
-           git_https_proxy=$HTTPS_PROXY
         fi
+        git_https_proxy="${HTTPS_PROXY-}"
+        git_http_proxy="${HTTP_PROXY-}"
+
 	# generate install script
 	_cd ${BUILD_DIR}
 	cat > install_package_in_image.sh <<EOF 


### PR DESCRIPTION
This fixes an issue on the vcad_build.sh build script when not setting HTTP_PROXY env. 
The script fails with the following error:

```
/home/root/VCAC-SW-Analytics/VCAC-A/Intel_Media_Analytics_Node/scripts/vcad_build.sh: line 664: HTTP_PROXY: unbound variable
```

The script has 'set -u' so it fails when a variable is undefined. 
